### PR TITLE
Add model command option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is a PHP command-line tool based on Symfony Console. It allows you 
 
 - PHP 7.4 or higher
 - Composer
-- An account and API key for a large language model (LLM) service such as OpenAI.
+- An account and API key for a large language model (LLM) service such as OpenAI or Perplexity.
 
 ## Installation
 
@@ -47,6 +47,7 @@ This project is a PHP command-line tool based on Symfony Console. It allows you 
     - `--apiKey`: API key for authentication.
     - `--existingTags`: List of existing tags that can be used.
     - `--locale`: Language to use (default is `en_US`).
+    - `--model`: Model to use (default is `gpt-4o-mini`).
 
 2. **pictures-to-tags**
 
@@ -91,6 +92,11 @@ This project is a PHP command-line tool based on Symfony Console. It allows you 
 ## Configuration
 
 You can configure default options such as `baseUri` and `locale` directly in the code or via environment variables.
+
+## Current Limitation
+
+The Perplexity API only accepts plain text messages in the `content` field. Sending multimodal data (such as images, audio, or objects like `image_url`) is not supported at this time. Any attempt to send non-text content will result in an error such as “Message content was empty.”
+See the [official documentation for supported formats](https://docs.perplexity.ai/api-reference/chat-completions).
 
 ## Authors
 

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -41,6 +41,13 @@ abstract class BaseCommand extends Command
             'Lang to use',
             'en_US'
         );
+        $this->addOption(
+            'model',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Model to use',
+            'gpt-4o-mini'
+        );
     }
 
     protected function getClient(InputInterface $input): Client

--- a/src/Command/PicturesToDescriptionCommand.php
+++ b/src/Command/PicturesToDescriptionCommand.php
@@ -30,8 +30,9 @@ class PicturesToDescriptionCommand extends BaseCommand
         $pictures = $input->getArgument('pictures');
         $lang = $input->getOption('locale');
         $existingTags = $input->getOption('existingTags');
+        $model = $input->getOption('model');
 
-        $picturesToDescription = new GenerateDescription($client);
+        $picturesToDescription = new GenerateDescription($client, $model);
         $description = $picturesToDescription->fromPictures($pictures, $lang, $existingTags);
         $desc = $description['content'][0];
 

--- a/src/Command/PicturesToProductCommand.php
+++ b/src/Command/PicturesToProductCommand.php
@@ -29,8 +29,9 @@ class PicturesToProductCommand extends BaseCommand
 
         $pictures = $input->getArgument('pictures');
         $lang = $input->getOption('locale');
+        $model = $input->getOption('model');
 
-        $pictureToProduct = new PictureToProduct($client);
+        $pictureToProduct = new PictureToProduct($client, $model);
         $description = $pictureToProduct->fromPictures($pictures, $lang);
 
         $desc = $description['content'];

--- a/src/Command/PicturesToTagsCommand.php
+++ b/src/Command/PicturesToTagsCommand.php
@@ -29,8 +29,9 @@ class PicturesToTagsCommand extends BaseCommand
         $pictures = $input->getArgument('pictures');
         $lang = $input->getOption('locale');
         $existingTags = $input->getOption('existingTags');
+        $model = $input->getOption('model');
 
-        $pictureToTag = new GenerateTags($client);
+        $pictureToTag = new GenerateTags($client, $model);
         $tags = $pictureToTag->fromPictures($pictures, $lang, $existingTags);
 
         $this->renderTable($input, $output, array_map(function ($tag) {

--- a/src/Command/TextToDescriptionCommand.php
+++ b/src/Command/TextToDescriptionCommand.php
@@ -30,8 +30,9 @@ class TextToDescriptionCommand extends BaseCommand
         $text = $input->getArgument('text');
         $lang = $input->getOption('locale');
         $existingTags = $input->getOption('existingTags');
+        $model = $input->getOption('model');
 
-        $textToDescription = new GenerateDescription($client);
+        $textToDescription = new GenerateDescription($client, $model);
         $description = $textToDescription->fromText($text, $lang, $existingTags);
         $desc = $description['content'][0];
 

--- a/src/Command/TextToTagsCommand.php
+++ b/src/Command/TextToTagsCommand.php
@@ -35,8 +35,9 @@ class TextToTagsCommand extends BaseCommand
         $text = $input->getArgument('text');
         $lang = $input->getOption('locale');
         $existingTags = $input->getOption('existingTags');
+        $model = $input->getOption('model');
 
-        $generateTagsService = new GenerateTags($client);
+        $generateTagsService = new GenerateTags($client, $model);
         $tags = $generateTagsService->fromText($text, $lang, $existingTags);
 
         $data = array_map(function ($tag) {

--- a/src/Service/GenerateDescription.php
+++ b/src/Service/GenerateDescription.php
@@ -91,7 +91,7 @@ class GenerateDescription
     private function execute(array $messages)
     {
         $result = $this->client->chat()->create([
-            'model' => 'gpt-4o-mini',
+            'model' => $this->model,
             'messages' => $messages,
             'response_format' => [
                 'type' => 'json_schema',

--- a/src/Service/GenerateTags.php
+++ b/src/Service/GenerateTags.php
@@ -90,7 +90,7 @@ class GenerateTags
     private function execute(array $messages)
     {
         $result = $this->client->chat()->create([
-            'model' => 'gpt-4o-mini',
+            'model' => $this->model,
             'messages' => $messages,
             'response_format' => [
                 'type' => 'json_schema',

--- a/src/Service/PictureToProduct.php
+++ b/src/Service/PictureToProduct.php
@@ -58,7 +58,7 @@ class PictureToProduct
     private function execute(array $messages)
     {
         $result = $this->client->chat()->create([
-            'model' => 'gpt-4o-mini',
+            'model' => $this->model,
             'messages' => $messages,
             'response_format' => [
                 'type' => 'json_schema',


### PR DESCRIPTION
To use a LLM model other than the default one (gpt-4o-mini), this PR propose to add a model option. 

I used Perplexity for my tests with Sonar model. 